### PR TITLE
Docker now contains the wordpress installation

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+# Docker
+
+
+## Please note
+Files in this folder are used to build a docker image for the project.
+They will __NEED__ to be placed in the root of the project, not here.
+I have included them here so that they are visible in the repository.
+
+Once you have moved the files to the root of the project, you can run the container with:
+```bash
+docker compose up -d
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  db:
+    image: mysql:5.7
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: somewordpress
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+
+  wordpress:
+    depends_on:
+      - db
+    image: wordpress:5.1.1-php7.3-apache
+    ports:
+      - "8000:80"
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+    working_dir: /var/www/html
+    volumes:
+      - ./wp-content:/var/www/html/wp-content
+volumes:
+  db_data:


### PR DESCRIPTION
After testing the port forwarding I can visit [8000](http://localhost:8000/) and see wordpress before me. After clicking through the installation process, the theme is already there.